### PR TITLE
Example of how to serve .h5 files outside plumber as mentioned in #10

### DIFF
--- a/compose/docker-compose.yml
+++ b/compose/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - ./nginx-conf:/etc/nginx/conf.d
       - /etc/letsencrypt:/etc/letsencrypt
       - /var/log/nginx:/var/log/nginx
+      - ./bioatlas:/bioatlas
     networks:
       - app-network
 

--- a/compose/nginx-conf/basic.conf
+++ b/compose/nginx-conf/basic.conf
@@ -1,6 +1,13 @@
 server {
   listen 80;
   # server_name default;
+
+  # exception to the proxy_pass of root
+  location ^~ /bioatlas {
+    # we know plumber.R has set this up
+    alias /bioatlas; # rename as h5files
+  }
+
   location / {
          proxy_pass http://bioatlas:8000;
       }


### PR DESCRIPTION
Right, here we have:

1. path mounted which was setup with `.h5` files manually on a server
2. Nginx is setup to have an exception to the full `proxy_pass` directive.

And this should now serve .h5 files, for instance from the test Jasmin server.